### PR TITLE
use ruff instead of flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,3 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.pydocstyle]
 convention = "google"
-
-[tool.ruff.mccabe]
-max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,20 +14,19 @@ log_cli_level = "INFO"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,10 +6,9 @@
 import unittest
 
 import ops.testing
+from charm import GrafanaCloudIntegratorCharm
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
-
-from charm import GrafanaCloudIntegratorCharm
 
 
 class TestCharm(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -26,20 +26,16 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8-docstrings
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     # uncomment the following line if this charm owns a lib
@@ -52,9 +48,7 @@ commands =
       --skip venv \
       --skip .mypy_cache \
       --skip icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same!