### PR TITLE
generalize charm to work with any prom and loki url

### DIFF
--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
@@ -5,7 +5,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "2a48eccc49a346f08879b11ecab4465a"
 LIBAPI = 0
-LIBPATCH = 2
+LIBPATCH = 3
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
@@ -49,9 +49,6 @@ class GrafanaCloudConfigProvider(Object):
         if not self._charm.unit.is_leader():
             return
         
-        if not self._charm.credentials_configured:
-            return
-
         for relation in self._charm.model.relations[self._relation_name]:
             databag = relation.data[self._charm.app]
             for k, v in (

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
@@ -51,11 +51,9 @@ class GrafanaCloudConfigProvider(Object):
         
         for relation in self._charm.model.relations[self._relation_name]:
             databag = relation.data[self._charm.app]
-            for k, v in (
-                ("username", self._credentials.username),
-                ("password", self._credentials.password),
-            ):                
-                databag[k] = v 
+            if self._credentials:
+                databag["username"] = self._credentials.username
+                databag["password"] = self._credentials.password
             if self._charm.loki_configured:
                 databag["loki_url"] = self._loki_url
             if self._charm.prom_configured:

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -88,6 +88,7 @@ class GrafanaCloudConfigRequirer(Object):
 
     @property
     def credentials(self):
+        """Return the credentials, if any; otherwise, return None."""
         if not all(
             self._is_not_empty(x)
             for x in [

--- a/src/charm.py
+++ b/src/charm.py
@@ -42,9 +42,6 @@ class GrafanaCloudIntegratorCharm(CharmBase):
         self.unit.status = self.app.status = self._get_status()
 
     def _get_status(self):
-        if not self.credentials_configured:
-            return BlockedStatus("Credentials missing")
-
         if not self.loki_configured and not self.prom_configured:
             return BlockedStatus("No outputs configured")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,7 +41,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"prometheus-url": "https://example.org"})
         self.assertTrue(self.harness.charm.prom_configured)
         self.assertFalse(self.harness.charm.loki_configured)
-        self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
 
     def test_loki_url_is_propagated(self):
         """Test that when a Loki URL has been configured, the charm knows about it."""
@@ -53,7 +53,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertTrue(self.harness.charm.loki_configured)
         self.assertFalse(self.harness.charm.prom_configured)
-        self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
 
     def test_credentials_are_propagated_only_username(self):
         """Test that when only username has been configured, the charm knows about it."""

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,9 @@ commands =
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
 
+[testenv:scenario]
+description = Run scenario tests
+
 [testenv:integration]
 description = Run integration tests
 deps =


### PR DESCRIPTION
## Issue
The charm needs to be able to work with any `prometheus-url` and `loki-url`, be it authenticated or not.


## Solution
Remove the checks that make credentials compulsory.


## Context
Being able to write metrics and logs to multiple backends through grafana-agent.


## Testing Instructions
```bash
juju deploy ./grafana-agent.charm
juju deploy prometheus
juju deploy ./grafana-cloud-integrator.charm

juju config grafana-cloud-integrator prometheus-url=<prometheus-url>
juju relate grafana-agent:grafana-cloud-config grafana-cloud-integrator
```
Metrics will appear in Prometheus.
