### PR TITLE
fix: remove unnecessary leadership guards in GrafanaCloudConfigRequirer

### DIFF
--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -6,7 +6,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "e6f580481c1b4388aa4d2cdf412a47fa"
 LIBAPI = 0
-LIBPATCH = 4
+LIBPATCH = 6
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
@@ -53,15 +53,9 @@ class GrafanaCloudConfigRequirer(Object):
             self.framework.observe(event, self._on_relation_broken)
 
     def _on_relation_changed(self, event):
-        if not self._charm.unit.is_leader():
-            return
-
         self.on.cloud_config_available.emit()  # pyright: ignore
 
     def _on_relation_broken(self, event):
-        if not self._charm.unit.is_leader():
-            return
-
         self.on.cloud_config_revoked.emit()  # pyright: ignore
     
     def _is_not_empty(self, s):

--- a/tests/scenario/test_grafana_cloud_integrator_lib.py
+++ b/tests/scenario/test_grafana_cloud_integrator_lib.py
@@ -29,7 +29,9 @@ def mycharm_context():
 
 
 @pytest.mark.parametrize("is_leader", [(True,), (False,)])
-def test_requirer_emits_cloud_config_available_event_on_relation_changed(is_leader, mycharm_context):
+def test_requirer_emits_cloud_config_available_event_on_relation_changed(
+    is_leader, mycharm_context
+):
     # GIVEN a grafana-cloud-config relation and a leadership status
     grafana_cloud_config_relation = Relation("grafana-cloud-config")
     state = State(leader=is_leader, relations=[grafana_cloud_config_relation])
@@ -38,7 +40,11 @@ def test_requirer_emits_cloud_config_available_event_on_relation_changed(is_lead
     mycharm_context.run(grafana_cloud_config_relation.changed_event, state)
 
     # THEN the CloudConfigAvailableEvent event is emitted
-    assert any(event for event in mycharm_context.emitted_events if isinstance(event, CloudConfigAvailableEvent))
+    assert any(
+        event
+        for event in mycharm_context.emitted_events
+        if isinstance(event, CloudConfigAvailableEvent)
+    )
 
 
 @pytest.mark.parametrize("is_leader", [(True,), (False,)])
@@ -52,4 +58,8 @@ def test_requirer_emits_cloud_config_revoked_event_on_relation_broken(is_leader,
     mycharm_context.run(grafana_cloud_config_relation.broken_event, state)
 
     # THEN the CloudConfigAvailableEvent event is emitted
-    assert any(event for event in mycharm_context.emitted_events if isinstance(event, CloudConfigRevokedEvent))
+    assert any(
+        event
+        for event in mycharm_context.emitted_events
+        if isinstance(event, CloudConfigRevokedEvent)
+    )

--- a/tests/scenario/test_grafana_cloud_integrator_lib.py
+++ b/tests/scenario/test_grafana_cloud_integrator_lib.py
@@ -28,13 +28,7 @@ def mycharm_context():
     )
 
 
-@pytest.mark.parametrize(
-    "is_leader",
-    [
-        (True,),
-        (False,),
-    ],
-)
+@pytest.mark.parametrize("is_leader", [(True,), (False,)])
 def test_requirer_emits_cloud_config_available_event_on_relation_changed(is_leader, mycharm_context):
     # GIVEN a grafana-cloud-config relation and a leadership status
     grafana_cloud_config_relation = Relation("grafana-cloud-config")
@@ -47,13 +41,7 @@ def test_requirer_emits_cloud_config_available_event_on_relation_changed(is_lead
     assert any(event for event in mycharm_context.emitted_events if isinstance(event, CloudConfigAvailableEvent))
 
 
-@pytest.mark.parametrize(
-    "is_leader",
-    [
-        (True,),
-        (False,),
-    ],
-)
+@pytest.mark.parametrize("is_leader", [(True,), (False,)])
 def test_requirer_emits_cloud_config_revoked_event_on_relation_broken(is_leader, mycharm_context):
     # GIVEN a grafana-cloud-config relation
     grafana_cloud_config_relation = Relation("grafana-cloud-config")

--- a/tests/scenario/test_grafana_cloud_integrator_lib.py
+++ b/tests/scenario/test_grafana_cloud_integrator_lib.py
@@ -15,7 +15,8 @@ class MyCharm(CharmBase):
 
 
 @pytest.fixture()
-def context():
+def mycharm_context():
+    """Returns a Context object with a MyCharm instance."""
     return Context(
         charm_type=MyCharm,
         meta={
@@ -34,17 +35,16 @@ def context():
         (False,),
     ],
 )
-def test_requirer_emits_cloud_config_available_event_on_relation_changed(is_leader, context):
-    # GIVEN a grafana-cloud-config relation
+def test_requirer_emits_cloud_config_available_event_on_relation_changed(is_leader, mycharm_context):
+    # GIVEN a grafana-cloud-config relation and a leadership status
     grafana_cloud_config_relation = Relation("grafana-cloud-config")
-    # AND GIVEN leadership/non-leadership
     state = State(leader=is_leader, relations=[grafana_cloud_config_relation])
 
     # WHEN the grafana-cloud-config relation changes
-    context.run(grafana_cloud_config_relation.changed_event, state)
+    mycharm_context.run(grafana_cloud_config_relation.changed_event, state)
 
     # THEN the CloudConfigAvailableEvent event is emitted
-    any(event for event in context.emitted_events if isinstance(event, CloudConfigAvailableEvent))
+    assert any(event for event in mycharm_context.emitted_events if isinstance(event, CloudConfigAvailableEvent))
 
 
 @pytest.mark.parametrize(
@@ -54,14 +54,14 @@ def test_requirer_emits_cloud_config_available_event_on_relation_changed(is_lead
         (False,),
     ],
 )
-def test_requirer_emits_cloud_config_revoked_event_on_relation_broken(is_leader, context):
+def test_requirer_emits_cloud_config_revoked_event_on_relation_broken(is_leader, mycharm_context):
     # GIVEN a grafana-cloud-config relation
     grafana_cloud_config_relation = Relation("grafana-cloud-config")
     # AND GIVEN leadership/non-leadership
     state = State(leader=is_leader, relations=[grafana_cloud_config_relation])
 
     # WHEN the grafana-cloud-config relation changes
-    context.run(grafana_cloud_config_relation.broken_event, state)
+    mycharm_context.run(grafana_cloud_config_relation.broken_event, state)
 
     # THEN the CloudConfigAvailableEvent event is emitted
-    any(event for event in context.emitted_events if isinstance(event, CloudConfigRevokedEvent))
+    assert any(event for event in mycharm_context.emitted_events if isinstance(event, CloudConfigRevokedEvent))

--- a/tests/scenario/test_grafana_cloud_integrator_lib.py
+++ b/tests/scenario/test_grafana_cloud_integrator_lib.py
@@ -1,0 +1,67 @@
+import pytest
+from charms.grafana_cloud_integrator.v0.cloud_config_requirer import (
+    CloudConfigAvailableEvent,
+    CloudConfigRevokedEvent,
+    GrafanaCloudConfigRequirer,
+)
+from ops import CharmBase, Framework
+from scenario import Context, Relation, State
+
+
+class MyCharm(CharmBase):
+    def __init__(self, framework: Framework):
+        super().__init__(framework)
+        self.cloud = GrafanaCloudConfigRequirer(self)
+
+
+@pytest.fixture()
+def context():
+    return Context(
+        charm_type=MyCharm,
+        meta={
+            "name": "my-charm",
+            "requires": {
+                "grafana-cloud-config": {"interface": "grafana_cloud_config", "limit": 1}
+            },
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "is_leader",
+    [
+        (True,),
+        (False,),
+    ],
+)
+def test_requirer_emits_cloud_config_available_event_on_relation_changed(is_leader, context):
+    # GIVEN a grafana-cloud-config relation
+    grafana_cloud_config_relation = Relation("grafana-cloud-config")
+    # AND GIVEN leadership/non-leadership
+    state = State(leader=is_leader, relations=[grafana_cloud_config_relation])
+
+    # WHEN the grafana-cloud-config relation changes
+    context.run(grafana_cloud_config_relation.changed_event, state)
+
+    # THEN the CloudConfigAvailableEvent event is emitted
+    any(event for event in context.emitted_events if isinstance(event, CloudConfigAvailableEvent))
+
+
+@pytest.mark.parametrize(
+    "is_leader",
+    [
+        (True,),
+        (False,),
+    ],
+)
+def test_requirer_emits_cloud_config_revoked_event_on_relation_broken(is_leader, context):
+    # GIVEN a grafana-cloud-config relation
+    grafana_cloud_config_relation = Relation("grafana-cloud-config")
+    # AND GIVEN leadership/non-leadership
+    state = State(leader=is_leader, relations=[grafana_cloud_config_relation])
+
+    # WHEN the grafana-cloud-config relation changes
+    context.run(grafana_cloud_config_relation.broken_event, state)
+
+    # THEN the CloudConfigAvailableEvent event is emitted
+    any(event for event in context.emitted_events if isinstance(event, CloudConfigRevokedEvent))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,9 +6,10 @@
 import unittest
 
 import ops.testing
-from charm import GrafanaCloudIntegratorCharm
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
+
+from charm import GrafanaCloudIntegratorCharm
 
 
 class TestCharm(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -92,4 +92,4 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}integration

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,15 @@ commands =
 
 [testenv:scenario]
 description = Run scenario tests
+deps =
+    pytest
+    coverage[toml]
+    ops-scenario>=4.0.3
+    -r{toxinidir}/requirements.txt
+commands =
+    coverage run --source={[vars]src_path} \
+        -m pytest  -v --tb native -s {posargs} {[vars]tst_path}scenario
+    coverage report
 
 [testenv:integration]
 description = Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+        -m pytest -v --tb native -s {posargs} {[vars]tst_path}unit
     coverage report
 
 [testenv:scenario]


### PR DESCRIPTION
## Issue
Previously, GrafanaCloudConfigRequirer would only emit a cloud_config_* event on relation changed/broken if this unit is a leader.  This caused issues with multi-unit deployments as described in [#12](https://github.com/canonical/grafana-cloud-integrator/issues/12).  

## Solution
Since GrafanaCloudConfigRequirer only reads the relation remote's application_data, there is no need for a leadership guard because non-leader units have permission to read this data.  The current commit removes these guards.

## Context
closes #12

## Testing Instructions
See [this grafana-agent patch](https://github.com/canonical/grafana-agent-operator/pull/168) for testing instructions

## Release Notes
<!-- A digestable summary of the change in this PR -->
