### PR TITLE
Fix credentials logic

### DIFF
--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -57,7 +57,7 @@ class GrafanaCloudConfigRequirer(Object):
 
     def _on_relation_broken(self, event):
         self.on.cloud_config_revoked.emit()  # pyright: ignore
-    
+
     def _is_not_empty(self, s):
         return bool(s and not s.isspace())
 
@@ -83,7 +83,7 @@ class GrafanaCloudConfigRequirer(Object):
     @property
     def credentials(self):
         """Return the credentials, if any; otherwise, return None."""
-        if (username := self._data.get("username").strip()) and (password := self._data.get("password").strip()):
+        if (username := self._data.get("username", "").strip()) and (password := self._data.get("password", "").strip()):
             return Credentials(username, password)
         return None
 
@@ -116,7 +116,7 @@ class GrafanaCloudConfigRequirer(Object):
         """Return the prometheus endpoint dict."""
         if not self.prometheus_ready:
             return {}
-        
+
         endpoint = {}
         endpoint["url"] = self.prometheus_url
         if self.credentials:

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -6,7 +6,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "e6f580481c1b4388aa4d2cdf412a47fa"
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
@@ -83,16 +83,8 @@ class GrafanaCloudConfigRequirer(Object):
     @property
     def credentials(self):
         """Return the credentials, if any; otherwise, return None."""
-        if not all(
-            self._is_not_empty(x)
-            for x in [
-                self._data.get("username", ""),
-                self._data.get("password", ""),
-            ]):
-                return Credentials(
-                    self._data.get("username", ""),
-                    self._data.get("password", "")
-                )
+        if (username := self._data.get("username").strip()) and (password := self._data.get("password").strip()):
+            return Credentials(username, password)
         return None
 
     @property

--- a/tests/scenario/test_grafana_cloud_integrator_lib.py
+++ b/tests/scenario/test_grafana_cloud_integrator_lib.py
@@ -37,7 +37,9 @@ def test_requirer_emits_cloud_config_available_event_on_relation_changed(
     state = State(leader=is_leader, relations=[grafana_cloud_config_relation])
 
     # WHEN the grafana-cloud-config relation changes
-    mycharm_context.run(grafana_cloud_config_relation.changed_event, state)
+    mycharm_context.run(
+        mycharm_context.on.relation_changed(relation=grafana_cloud_config_relation), state
+    )
 
     # THEN the CloudConfigAvailableEvent event is emitted
     assert any(
@@ -55,7 +57,9 @@ def test_requirer_emits_cloud_config_revoked_event_on_relation_broken(is_leader,
     state = State(leader=is_leader, relations=[grafana_cloud_config_relation])
 
     # WHEN the grafana-cloud-config relation changes
-    mycharm_context.run(grafana_cloud_config_relation.broken_event, state)
+    mycharm_context.run(
+        mycharm_context.on.relation_broken(relation=grafana_cloud_config_relation), state
+    )
 
     # THEN the CloudConfigAvailableEvent event is emitted
     assert any(

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ description = Run scenario tests
 deps =
     pytest
     coverage[toml]
-    ops-scenario>=4.0.3
+    ops-scenario
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The [`if not all(....`](https://github.com/canonical/grafana-cloud-integrator/blob/main/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py#L86) logic is wrong.
We want to return `Credentials(username, password)` if username and password are present.


We have simplified and fixed the logic.

## Solution
<!-- A summary of the solution addressing the above issue -->

Addresses #18.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

In the context of Grafana agent charms we've seen that the configuration file is not rendered correctly. Although `username` and `password` are configured in grafana-cloud-operator, and the data transmitted over relation data, those values were not rendered into grafana-agent config file because this wrong logic
