### PR TITLE
feat: support external ca

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,3 +28,7 @@ options:
       services provided by Grafana Cloud.
     value: ""
     type: string
+  tls-ca:
+    description: |
+      The CA cert used by the remote Prometheus and Loki endpoints.
+    type: string

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
@@ -1,15 +1,15 @@
 """Grafana Cloud Integrator Configuration Requirer."""
 
-from ops.framework import EventBase, EventSource, Object, ObjectEvents
-
+from ops.framework import Object
 
 LIBID = "2a48eccc49a346f08879b11ecab4465a"
 LIBAPI = 0
-LIBPATCH = 3
+LIBPATCH = 4
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
 class Credentials:
+    """Credentials for the remote endpoints."""
     def __init__(self, username, password):
         self.username = username
         self.password = password
@@ -18,10 +18,10 @@ class GrafanaCloudConfigProvider(Object):
     """Provider side of the Grafana Cloud Config relation."""
 
     def __init__(
-        self, 
-        charm, 
-        credentials: Credentials, 
-        prometheus_url: str, 
+        self,
+        charm,
+        credentials: Credentials,
+        prometheus_url: str,
         loki_url: str,
         relation_name: str = DEFAULT_RELATION_NAME,
     ):
@@ -41,14 +41,14 @@ class GrafanaCloudConfigProvider(Object):
             self._charm.on.config_changed,
         ]:
             self.framework.observe(
-               event, 
+               event,
                self._on_relation_changed,
             )
 
     def _on_relation_changed(self, event):
         if not self._charm.unit.is_leader():
             return
-        
+
         for relation in self._charm.model.relations[self._relation_name]:
             databag = relation.data[self._charm.app]
             if self._credentials:
@@ -58,3 +58,4 @@ class GrafanaCloudConfigProvider(Object):
                 databag["loki_url"] = self._loki_url
             if self._charm.prom_configured:
                 databag["prometheus_url"] = self._prometheus_url
+            databag["tls-ca"] = self._charm.config.get("tls-ca", "")

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
@@ -8,11 +8,14 @@ LIBPATCH = 4
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
+
 class Credentials:
     """Credentials for the remote endpoints."""
+
     def __init__(self, username, password):
         self.username = username
         self.password = password
+
 
 class GrafanaCloudConfigProvider(Object):
     """Provider side of the Grafana Cloud Config relation."""
@@ -41,8 +44,8 @@ class GrafanaCloudConfigProvider(Object):
             self._charm.on.config_changed,
         ]:
             self.framework.observe(
-               event,
-               self._on_relation_changed,
+                event,
+                self._on_relation_changed,
             )
 
     def _on_relation_changed(self, event):

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = lint, unit
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
 lib_path = {toxinidir}/lib/charms/grafana_cloud_integrator
-all_path = {[vars]src_path} {[vars]tst_path} 
+all_path = {[vars]src_path} {[vars]lib_path} {[vars]tst_path} 
 
 [testenv]
 setenv =


### PR DESCRIPTION
## Issue
Closes #20.
We need two tandem PRs for the Grafana agents, which should be **tested before** and **merged after** this one gets merged:
- https://github.com/canonical/grafana-agent-k8s-operator/pull/330
- https://github.com/canonical/grafana-agent-operator/pull/206

## Solution
Add `tls-ca` as a Juju config option:
- in the provider, make sure it's sent via relation data;
- in the requirer, make sure it's accessible from relation data.

## Testing Instructions

Without the tandem PRs:
1. Deploy `grafana-cloud-integrator` from this branch
2. Deploy `grafana-agent-k8s`
3. `juju relate` the two of them
4. `juju config grafana-cloud-integrator tls-ca=something`
5. Verify it's in relation data with `jhack show-relation` (or `juju show-unit`)

With the tandem PRs:
1. Deploy `grafana-cloud-integrator` from this branch
2. Deploy `grafana-agent-k8s` from the linked PR
3. `juju relate` the two of them
4. `juju config grafana-cloud-integrator tls-ca=something`
5. `juju ssh --container=agent agent/0 cat /usr/local/share/ca-certificates/cloud-integrator.crt`
