### PR TITLE
Add ubuntu@22.04 to platforms

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,6 +24,7 @@ links:
   issues: https://github.com/canonical/grafana-cloud-integrator/issues
 
 platforms:
+  ubuntu@22.04:amd64:
   ubuntu@24.04:amd64:
 
 parts:


### PR DESCRIPTION
## Issue
This is a workloadless charm that can be deployed on k8s or VM, but the list of platforms only has 24.04, preventing it from being deployed to a 22.04 machine.


## Solution
Add 22.04.
