### PR TITLE
Support multiple seprarate signals auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you also need to provide a custom CA, create `grafana-cloud-ca.pem`:
 Then configure the charm:
 
 ```sh
-juju deploy grafana-cloud-integrator --channel=stable
+juju deploy grafana-cloud-integrator
 
 juju config grafana-cloud-integrator \
   prometheus-url="https://prometheus-prod-39-prod-eu-north-0.grafana.net/api/prom/push"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ observability relations provided by COS for use with Grafana Cloud.
 
 ## Getting Started
 
-### Basic Deployment
+### Deploy the Integrator
 
 Create a Juju model for your operator, say "observability"
 
@@ -46,3 +46,176 @@ The Grafana Cloud Charmed Integrator may now be deployed using the Juju command 
 juju deploy grafana-cloud-integrator --channel=stable
 ```
 
+### get a Grafana cloud token with the appropriate permissions
+
+Get an API token with the following scopes to cover all the signals write permissions, you can change these to fit your needs and signals you intend to support with the deployment:
+
+- metrics:write
+- metrics:import
+- logs:write
+- traces:write
+- alerts:write
+- rules:write
+- profiles:write
+
+### Configuration Modes
+
+The charm supports two credential modes:
+
+- Shared credentials with `username` and `password`
+- Per-signal credentials with `signal-credentials`
+
+Do not set both modes at the same time. If both shared credentials and
+`signal-credentials` are configured, the charm will go to `blocked`.
+
+### Supported Signal Names
+
+The `signal-credentials` option accepts a YAML mapping with these supported
+top-level signal names:
+
+- `prometheus`
+- `loki`
+- `tempo`
+- `otlp`
+- `pyroscope`
+
+Each signal entry may define:
+
+- `username`
+- `password`
+
+### Complete Example
+
+This example configures:
+
+- Prometheus remote write to Grafana Cloud
+- Loki push to Grafana Cloud
+- Tempo write to Grafana Cloud
+- OTLP ingest to Grafana Cloud
+- Pyroscope profile write to Grafana Cloud
+- Separate credentials per signal
+
+Create a `signals.yaml` file:
+
+```yaml
+prometheus:
+  username: "1076854"
+  password: "<api-token>"
+loki:
+  username: "639149"
+  password: "glc_loki_token"
+tempo:
+  username: "123456"
+  password: "glc_tempo_token"
+otlp:
+  instance-id: "1076854"
+  password: "glc_otlp_token"
+pyroscope:
+  username: "424242"
+  password: "glc_pyroscope_token"
+```
+
+If you also need to provide a custom CA, create `grafana-cloud-ca.pem`:
+
+```pem
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+```
+
+Then configure the charm:
+
+```sh
+juju deploy grafana-cloud-integrator --channel=stable
+
+juju config grafana-cloud-integrator \
+  prometheus-url="https://prometheus-prod-39-prod-eu-north-0.grafana.net/api/prom/push"
+
+juju config grafana-cloud-integrator \
+  loki-url="https://logs-prod-025.grafana.net/loki/api/v1/push"
+
+juju config grafana-cloud-integrator \
+  tempo-url="https://tempo-prod-10-prod-eu-north-0.grafana.net/otlp"
+
+juju config grafana-cloud-integrator \
+  otlp-url="https://otlp-gateway-prod-eu-north-0.grafana.net/otlp"
+
+juju config grafana-cloud-integrator \
+  pyroscope-url="https://profiles-prod-010.grafana.net"
+
+juju config grafana-cloud-integrator \
+  signal-credentials="$(cat signals.yaml)"
+
+juju config grafana-cloud-integrator \
+  tls-ca="$(cat grafana-cloud-ca.pem)"
+```
+
+Relate a consumer charm that supports the `grafana-cloud-config` interface:
+
+```sh
+juju relate alloy-sub grafana-cloud-integrator
+```
+
+Or:
+
+```sh
+juju relate alloy-vm grafana-cloud-integrator
+```
+
+Check status:
+
+```sh
+juju status grafana-cloud-integrator
+juju status alloy-sub
+```
+
+### Copy-Paste Ready Example
+
+This example creates the credentials file and configures the integrator in one
+go.
+
+```sh
+cat > signals.yaml <<'EOF'
+prometheus:
+  username: "1076854"
+  password: "glc_prometheus_token"
+loki:
+  username: "639149"
+  password: "glc_loki_token"
+tempo:
+  username: "123456"
+  password: "glc_tempo_token"
+otlp:
+  instance-id: "1076854"
+  password: "glc_otlp_token"
+pyroscope:
+  username: "424242"
+  password: "glc_pyroscope_token"
+EOF
+
+juju deploy grafana-cloud-integrator --channel=stable
+
+juju config grafana-cloud-integrator \
+  prometheus-url="https://prometheus-prod-39-prod-eu-north-0.grafana.net/api/prom/push" \
+  loki-url="https://logs-prod-025.grafana.net/loki/api/v1/push" \
+  tempo-url="https://tempo-prod-10-prod-eu-north-0.grafana.net/otlp" \
+  otlp-url="https://otlp-gateway-prod-eu-north-0.grafana.net/otlp" \
+  pyroscope-url="https://profiles-prod-010.grafana.net" \
+  signal-credentials="$(cat signals.yaml)"
+
+juju relate alloy-sub grafana-cloud-integrator
+```
+
+### Shared Credential Fallback
+
+If the same Grafana Cloud credentials work for every configured signal, you
+can use the legacy shared credential options instead:
+
+```sh
+juju config grafana-cloud-integrator \
+  username="1076854" \
+  password="glc_shared_token"
+```
+
+When shared credentials are used, the same username and password are exposed to
+all configured signals.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -58,6 +58,17 @@ config:
         Grafana Cloud.
       value: ""
       type: string
+    otlp-url:
+      description: >
+        The full URL of the OTLP ingest endpoint provided by Grafana Cloud.
+      value: ""
+      type: string
+    pyroscope-url:
+      description: >
+        The full URL of the Pyroscope profiling write endpoint provided by
+        Grafana Cloud.
+      value: ""
+      type: string
     loki-url:
       description: >
         The full URL of the Loki Push API endpoint provided by
@@ -74,6 +85,25 @@ config:
       description: >
         The password (API Key/Token) used to authenticate to the cloud
         services provided by Grafana Cloud.
+      value: ""
+      type: string
+    signal-credentials:
+      description: >
+        Structured per-signal credentials as YAML. Use this instead of the
+        shared username/password when different Grafana Cloud signals require
+        different credentials. Example:
+          prometheus:
+            username: "1076854"
+            password: "..."
+          loki:
+            username: "639149"
+            password: "..."
+          pyroscope:
+            username: "424242"
+            password: "..."
+          otlp:
+            instance-id: "1076854"
+            password: "..."
       value: ""
       type: string
     tls-ca:

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_provider.py
@@ -1,10 +1,12 @@
 """Grafana Cloud Integrator Configuration Requirer."""
 
+from typing import MutableMapping, Optional
+
 from ops.framework import Object
 
 LIBID = "2a48eccc49a346f08879b11ecab4465a"
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 8
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
@@ -17,16 +19,37 @@ class Credentials:
         self.password = password
 
 
+class SignalCredentials:
+    """Credentials grouped by telemetry signal."""
+
+    def __init__(
+        self,
+        prometheus: Optional[Credentials] = None,
+        loki: Optional[Credentials] = None,
+        tempo: Optional[Credentials] = None,
+        otlp: Optional[Credentials] = None,
+        pyroscope: Optional[Credentials] = None,
+    ):
+        self.prometheus = prometheus
+        self.loki = loki
+        self.tempo = tempo
+        self.otlp = otlp
+        self.pyroscope = pyroscope
+
+
 class GrafanaCloudConfigProvider(Object):
     """Provider side of the Grafana Cloud Config relation."""
 
     def __init__(
         self,
         charm,
-        credentials: Credentials,
+        credentials: Optional[Credentials],
         prometheus_url: str,
         loki_url: str,
         tempo_url: str,
+        otlp_url: str,
+        pyroscope_url: str,
+        signal_credentials: Optional[SignalCredentials] = None,
         relation_name: str = DEFAULT_RELATION_NAME,
     ):
         super().__init__(charm, relation_name)
@@ -35,6 +58,9 @@ class GrafanaCloudConfigProvider(Object):
         self._prometheus_url = prometheus_url
         self._loki_url = loki_url
         self._tempo_url = tempo_url
+        self._otlp_url = otlp_url
+        self._pyroscope_url = pyroscope_url
+        self._signal_credentials = signal_credentials or SignalCredentials()
         self._relation_name = relation_name
 
         relation_events = self._charm.on[relation_name]
@@ -51,20 +77,49 @@ class GrafanaCloudConfigProvider(Object):
             )
 
     def _on_relation_changed(self, event):
+        """Publish the currently configured Grafana Cloud settings to each relation."""
         if not self._charm.unit.is_leader():
             return
 
         for relation in self._charm.model.relations[self._relation_name]:
             databag = relation.data[self._charm.app]
+            self._set_or_delete(databag, "username", self._credential_value("shared", "username"))
+            self._set_or_delete(databag, "password", self._credential_value("shared", "password"))
+            self._set_or_delete(databag, "prometheus_url", self._prometheus_url)
+            self._set_or_delete(databag, "loki_url", self._loki_url)
+            self._set_or_delete(databag, "tempo_url", self._tempo_url)
+            self._set_or_delete(databag, "otlp_url", self._otlp_url)
+            self._set_or_delete(databag, "pyroscope_url", self._pyroscope_url)
+            self._set_or_delete(
+                databag, "prometheus_username", self._credential_value("prometheus", "username")
+            )
+            self._set_or_delete(
+                databag, "prometheus_password", self._credential_value("prometheus", "password")
+            )
+            self._set_or_delete(databag, "loki_username", self._credential_value("loki", "username"))
+            self._set_or_delete(databag, "loki_password", self._credential_value("loki", "password"))
+            self._set_or_delete(databag, "tempo_username", self._credential_value("tempo", "username"))
+            self._set_or_delete(databag, "tempo_password", self._credential_value("tempo", "password"))
+            self._set_or_delete(databag, "otlp_username", self._credential_value("otlp", "username"))
+            self._set_or_delete(databag, "otlp_password", self._credential_value("otlp", "password"))
+            self._set_or_delete(
+                databag, "pyroscope_username", self._credential_value("pyroscope", "username")
+            )
+            self._set_or_delete(
+                databag, "pyroscope_password", self._credential_value("pyroscope", "password")
+            )
+            self._set_or_delete(databag, "tls-ca", self._charm.config.get("tls-ca", ""))
 
-            # FIXME: this is always true
-            if self._credentials:
-                databag["username"] = self._credentials.username
-                databag["password"] = self._credentials.password
-            if self._loki_url:
-                databag["loki_url"] = self._loki_url
-            if self._tempo_url:
-                databag["tempo_url"] = self._tempo_url
-            if self._prometheus_url:
-                databag["prometheus_url"] = self._prometheus_url
-            databag["tls-ca"] = self._charm.config.get("tls-ca", "")
+    def _credential_value(self, signal: str, field: str) -> str:
+        """Return a credential field for either the shared or signal-specific mode."""
+        credentials = self._credentials if signal == "shared" else getattr(self._signal_credentials, signal)
+        if not credentials:
+            return ""
+        return getattr(credentials, field)
+
+    def _set_or_delete(self, databag: MutableMapping[str, str], key: str, value: Optional[str]) -> None:
+        """Keep relation data in sync by removing empty values."""
+        if value:
+            databag[key] = value
+            return
+        databag.pop(key, None)

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -210,7 +210,6 @@ class GrafanaCloudConfigRequirer(Object):
     @property
     def _data(self):
         for relation in self._charm.model.relations[self._relation_name]:
-            logger.info("%s %s %s", relation, self._relation_name, relation.data[relation.app])
             return relation.data[relation.app]
         return {}
 

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -6,7 +6,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "e6f580481c1b4388aa4d2cdf412a47fa"
 LIBAPI = 0
-LIBPATCH = 8
+LIBPATCH = 11
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
@@ -93,6 +93,31 @@ class GrafanaCloudConfigRequirer(Object):
         return None
 
     @property
+    def prometheus_credentials(self):
+        """Return Prometheus credentials, falling back to shared credentials."""
+        return self._signal_credentials("prometheus")
+
+    @property
+    def loki_credentials(self):
+        """Return Loki credentials, falling back to shared credentials."""
+        return self._signal_credentials("loki")
+
+    @property
+    def tempo_credentials(self):
+        """Return Tempo credentials, falling back to shared credentials."""
+        return self._signal_credentials("tempo")
+
+    @property
+    def otlp_credentials(self):
+        """Return OTLP credentials, falling back to shared credentials."""
+        return self._signal_credentials("otlp")
+
+    @property
+    def pyroscope_credentials(self):
+        """Return Pyroscope credentials, falling back to shared credentials."""
+        return self._signal_credentials("pyroscope")
+
+    @property
     def loki_ready(self):
         """Check whether there is a non-empty Loki url in relation data."""
         return self._is_not_empty(self.loki_url)
@@ -105,10 +130,10 @@ class GrafanaCloudConfigRequirer(Object):
 
         endpoint = {}
         endpoint["url"] = self.loki_url
-        if self.credentials:
+        if self.loki_credentials:
             endpoint["basic_auth"] = {
-                "username": self.credentials.username,
-                "password": self.credentials.password,
+                "username": self.loki_credentials.username,
+                "password": self.loki_credentials.password,
             }
         return endpoint
 
@@ -123,6 +148,16 @@ class GrafanaCloudConfigRequirer(Object):
         return self._is_not_empty(self.tempo_url)
 
     @property
+    def otlp_ready(self):
+        """Check whether there is a non-empty OTLP url in relation data."""
+        return self._is_not_empty(self.otlp_url)
+
+    @property
+    def pyroscope_ready(self):
+        """Check whether there is a non-empty Pyroscope url in relation data."""
+        return self._is_not_empty(self.pyroscope_url)
+
+    @property
     def tls_ca_ready(self):
         """Check whether there is a TLS CA in relation data."""
         return self._is_not_empty(self.tls_ca)
@@ -135,10 +170,10 @@ class GrafanaCloudConfigRequirer(Object):
 
         endpoint = {}
         endpoint["url"] = self.prometheus_url
-        if self.credentials:
+        if self.prometheus_credentials:
             endpoint["basic_auth"] = {
-                "username": self.credentials.username,
-                "password": self.credentials.password,
+                "username": self.prometheus_credentials.username,
+                "password": self.prometheus_credentials.password,
             }
         return endpoint
 
@@ -153,9 +188,19 @@ class GrafanaCloudConfigRequirer(Object):
         return self._data.get("tempo_url", "")
 
     @property
+    def otlp_url(self) -> str:
+        """The OTLP endpoint from relation data."""
+        return self._data.get("otlp_url", "")
+
+    @property
     def prometheus_url(self) -> str:
         """The Prometheus endpoint from relation data."""
         return self._data.get("prometheus_url", "")
+
+    @property
+    def pyroscope_url(self) -> str:
+        """The Pyroscope endpoint from relation data."""
+        return self._data.get("pyroscope_url", "")
 
     @property
     def tls_ca(self) -> str:
@@ -168,3 +213,13 @@ class GrafanaCloudConfigRequirer(Object):
             logger.info("%s %s %s", relation, self._relation_name, relation.data[relation.app])
             return relation.data[relation.app]
         return {}
+
+    def _signal_credentials(self, signal_name):
+        """Return signal-specific credentials or fall back to the shared pair."""
+        username_key = "{}_username".format(signal_name)
+        password_key = "{}_password".format(signal_name)
+        if (username := self._data.get(username_key, "").strip()) and (
+            password := self._data.get(password_key, "").strip()
+        ):
+            return Credentials(username, password)
+        return self.credentials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = "~=3.8"
 
 dependencies = [
   "ops",
+  "PyYAML",
 ]
 
 [project.optional-dependencies]

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,8 +11,11 @@ import typing
 from charms.grafana_cloud_integrator.v0.cloud_config_provider import (
     Credentials,
     GrafanaCloudConfigProvider,
+    SignalCredentials,
 )
 from ops import ActiveStatus, BlockedStatus, CharmBase, CollectStatusEvent
+
+from signal_credentials import parse_signal_credentials
 
 
 class GrafanaCloudIntegratorCharm(CharmBase):
@@ -23,28 +26,73 @@ class GrafanaCloudIntegratorCharm(CharmBase):
 
         self._config = GrafanaCloudConfigProvider(
             self,
-            Credentials(
-                typing.cast(str, self.config.get("username", "")),
-                typing.cast(str, self.config.get("password", "")),
-            ),
+            self._shared_credentials,
             loki_url=typing.cast(str, self.config.get("loki-url", "")),
             tempo_url=typing.cast(str, self.config.get("tempo-url", "")),
+            otlp_url=typing.cast(str, self.config.get("otlp-url", "")),
+            pyroscope_url=typing.cast(str, self.config.get("pyroscope-url", "")),
             prometheus_url=typing.cast(str, self.config.get("prometheus-url", "")),
+            signal_credentials=self._signal_credentials,
         )
 
         self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
 
+    @property
+    def _shared_credentials(self) -> typing.Optional[Credentials]:
+        """Return the shared credential pair when both values are configured."""
+        username = typing.cast(str, self.config.get("username", "")).strip()
+        password = typing.cast(str, self.config.get("password", "")).strip()
+        if username and password:
+            return Credentials(username, password)
+        return None
+
+    @property
+    def _shared_credentials_configured(self) -> bool:
+        """Check whether either shared credential config key is set."""
+        username = typing.cast(str, self.config.get("username", "")).strip()
+        password = typing.cast(str, self.config.get("password", "")).strip()
+        return bool(username or password)
+
+    @property
+    def _signal_credentials_raw(self) -> str:
+        """Return the raw structured signal credential config string."""
+        return typing.cast(str, self.config.get("signal-credentials", ""))
+
+    @property
+    def _signal_credentials(self) -> SignalCredentials:
+        """Parse the structured per-signal credentials from charm config."""
+        return parse_signal_credentials(self._signal_credentials_raw)
+
     def _on_collect_unit_status(self, event: CollectStatusEvent):
+        """Report readiness based on configured outputs and credential mode."""
         # each *-url config option tells us where to send telemetry of a given type.
         # this maps config option names to human-readable telemetry types, so we can report
         # via the status which ones are unset. We strip the config value just in case.
-        config_to_signal = (("loki-url", "Logs"), ("tempo-url", "Traces"), ("prometheus-url", "Metrics"))
+        if self._shared_credentials_configured and self._signal_credentials_raw.strip():
+            event.add_status(
+                BlockedStatus("Do not set both shared username/password and signal-credentials")
+            )
+            return
+
+        try:
+            self._signal_credentials
+        except ValueError as exc:
+            event.add_status(BlockedStatus(str(exc)))
+            return
+
+        config_to_signal = (
+            ("loki-url", "Logs"),
+            ("tempo-url", "Traces"),
+            ("otlp-url", "OTLP"),
+            ("pyroscope-url", "Profiles"),
+            ("prometheus-url", "Metrics"),
+        )
         output_configs = {
-            telemetry: bool(typing.cast(str, self.config.get(key, "")).strip()) for
-            key, telemetry in config_to_signal
+            telemetry: bool(typing.cast(str, self.config.get(key, "")).strip())
+            for key, telemetry in config_to_signal
         }
 
-        if not (self.config.get("username", "") and self.config.get("password", "")):
+        if not self._shared_credentials and not self._signal_credentials_raw.strip():
             # FIXME: should this be blocked in fact?
             event.add_status(ActiveStatus("username/password not configured."))
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -48,10 +48,8 @@ class GrafanaCloudIntegratorCharm(CharmBase):
 
     @property
     def _shared_credentials_configured(self) -> bool:
-        """Check whether either shared credential config key is set."""
-        username = typing.cast(str, self.config.get("username", "")).strip()
-        password = typing.cast(str, self.config.get("password", "")).strip()
-        return bool(username or password)
+        """Check whether a complete shared credential pair is configured."""
+        return self._shared_credentials is not None
 
     @property
     def _signal_credentials_raw(self) -> str:

--- a/src/signal_credentials.py
+++ b/src/signal_credentials.py
@@ -1,0 +1,65 @@
+"""Helpers for parsing signal-specific Grafana Cloud credentials."""
+
+from typing import Any, Mapping, Optional
+
+import yaml
+from charms.grafana_cloud_integrator.v0.cloud_config_provider import Credentials, SignalCredentials
+
+
+def parse_signal_credentials(raw_value: str) -> SignalCredentials:
+    """Parse YAML signal credentials into a typed per-signal credential set.
+
+    The parser accepts a top-level mapping where each key is a telemetry signal
+    name and each value is a mapping containing `username` and `password`.
+    """
+    if not raw_value.strip():
+        return SignalCredentials()
+
+    parsed = yaml.safe_load(raw_value)
+    if parsed is None:
+        return SignalCredentials()
+    if not isinstance(parsed, Mapping):
+        raise ValueError("signal-credentials must be a mapping")
+
+    credentials_by_signal = {}
+    for signal_name, signal_config in parsed.items():
+        credentials = _parse_signal_entry(signal_name, signal_config)
+        if credentials is not None:
+            credentials_by_signal[str(signal_name)] = credentials
+
+    return SignalCredentials(
+        prometheus=credentials_by_signal.get("prometheus"),
+        loki=credentials_by_signal.get("loki"),
+        tempo=credentials_by_signal.get("tempo"),
+        otlp=credentials_by_signal.get("otlp"),
+        pyroscope=credentials_by_signal.get("pyroscope"),
+    )
+
+
+def _parse_signal_entry(signal_name: Any, signal_config: Any) -> Optional[Credentials]:
+    """Parse one signal entry and validate that the pair is complete."""
+    if signal_config is None:
+        return None
+    if not isinstance(signal_config, Mapping):
+        raise ValueError(f"signal-credentials.{signal_name} must be a mapping")
+
+    username = _coerce_string(
+        signal_config.get("instance-id") if str(signal_name) == "otlp" else signal_config.get("username")
+    ) or _coerce_string(signal_config.get("username"))
+    password = _coerce_string(signal_config.get("password"))
+
+    if bool(username) != bool(password):
+        raise ValueError(
+            f"signal-credentials.{signal_name} must define both "
+            f"{'instance-id' if str(signal_name) == 'otlp' else 'username'} and password"
+        )
+    if not username:
+        return None
+    return Credentials(username=username, password=password)
+
+
+def _coerce_string(value: Any) -> str:
+    """Normalize config values to stripped strings."""
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -171,3 +171,22 @@ loki:
             self.harness.model.unit.status,
             BlockedStatus("Do not set both shared username/password and signal-credentials"),
         )
+
+    def test_incomplete_shared_credentials_do_not_block_signal_credentials(self):
+        """A leftover shared password without username should not block signal credentials."""
+        self.harness.update_config(
+            {
+                "loki-url": "https://logs.example.org/loki/api/v1/push",
+                "username": "",
+                "password": "leftover-shared-pass",
+                "signal-credentials": """
+loki:
+  username: "639149"
+  password: "loki-token"
+""",
+            }
+        )
+
+        self.harness.evaluate_status()
+
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -98,3 +98,76 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
+
+    def test_signal_credentials_can_configure_loki_without_shared_username_password(self):
+        """Signal-specific credentials should be accepted without shared credentials."""
+        self.harness.update_config(
+            {
+                "loki-url": "https://logs.example.org/loki/api/v1/push",
+                "signal-credentials": """
+loki:
+  username: "639149"
+  password: "loki-token"
+""",
+            }
+        )
+
+        self.harness.evaluate_status()
+
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
+
+    def test_signal_credentials_can_configure_pyroscope_without_shared_username_password(self):
+        """Signal-specific credentials should be accepted for Pyroscope."""
+        self.harness.update_config(
+            {
+                "pyroscope-url": "https://profiles.example.org",
+                "signal-credentials": """
+pyroscope:
+  username: "profile-user"
+  password: "profile-token"
+""",
+            }
+        )
+
+        self.harness.evaluate_status()
+
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
+
+    def test_signal_credentials_can_configure_otlp_with_instance_id(self):
+        """OTLP signal credentials should accept instance-id in place of username."""
+        self.harness.update_config(
+            {
+                "otlp-url": "https://otlp-gateway.example.org/otlp",
+                "signal-credentials": """
+otlp:
+  instance-id: "otlp-instance"
+  password: "otlp-token"
+""",
+            }
+        )
+
+        self.harness.evaluate_status()
+
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
+
+    def test_mixed_shared_and_signal_credentials_are_blocked(self):
+        """Shared credentials and signal credentials must not be set together."""
+        self.harness.update_config(
+            {
+                "loki-url": "https://logs.example.org/loki/api/v1/push",
+                "username": "shared-user",
+                "password": "shared-pass",
+                "signal-credentials": """
+loki:
+  username: "639149"
+  password: "loki-token"
+""",
+            }
+        )
+
+        self.harness.evaluate_status()
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Do not set both shared username/password and signal-credentials"),
+        )

--- a/tests/unit/test_grafana_cloud_integrator_lib.py
+++ b/tests/unit/test_grafana_cloud_integrator_lib.py
@@ -5,6 +5,7 @@ from charms.grafana_cloud_integrator.v0.cloud_config_requirer import (
     GrafanaCloudConfigRequirer,
 )
 from ops import CharmBase, Framework
+from ops.testing import Harness
 from scenario import Context, Relation, State
 
 
@@ -67,3 +68,103 @@ def test_requirer_emits_cloud_config_revoked_event_on_relation_broken(is_leader,
         for event in mycharm_context.emitted_events
         if isinstance(event, CloudConfigRevokedEvent)
     )
+
+
+def test_requirer_reads_signal_specific_credentials(mycharm_context):
+    harness = Harness(
+        MyCharm,
+        meta="""
+name: my-charm
+requires:
+  grafana-cloud-config:
+    interface: grafana_cloud_config
+""",
+    )
+    harness.begin()
+    relation_id = harness.add_relation("grafana-cloud-config", "grafana-cloud-integrator")
+    harness.add_relation_unit(relation_id, "grafana-cloud-integrator/0")
+    harness.update_relation_data(
+        relation_id,
+        "grafana-cloud-integrator",
+        {
+            "prometheus_url": "https://prom.example/api/prom/push",
+            "prometheus_username": "1076854",
+            "prometheus_password": "prom-token",
+            "loki_url": "https://logs.example/loki/api/v1/push",
+            "loki_username": "639149",
+            "loki_password": "loki-token",
+            "otlp_url": "https://otlp.example/otlp",
+            "otlp_username": "otlp-instance",
+            "otlp_password": "otlp-token",
+            "pyroscope_url": "https://profiles.example",
+            "pyroscope_username": "profile-user",
+            "pyroscope_password": "profile-token",
+        },
+    )
+
+    cloud = harness.charm.cloud
+    assert cloud.prometheus_url == "https://prom.example/api/prom/push"
+    prometheus_credentials = cloud.prometheus_credentials
+    assert prometheus_credentials is not None
+    assert prometheus_credentials.username == "1076854"
+    assert prometheus_credentials.password == "prom-token"
+    assert cloud.loki_url == "https://logs.example/loki/api/v1/push"
+    loki_credentials = cloud.loki_credentials
+    assert loki_credentials is not None
+    assert loki_credentials.username == "639149"
+    assert loki_credentials.password == "loki-token"
+    assert cloud.otlp_url == "https://otlp.example/otlp"
+    otlp_credentials = cloud.otlp_credentials
+    assert otlp_credentials is not None
+    assert otlp_credentials.username == "otlp-instance"
+    assert otlp_credentials.password == "otlp-token"
+    assert cloud.pyroscope_url == "https://profiles.example"
+    pyroscope_credentials = cloud.pyroscope_credentials
+    assert pyroscope_credentials is not None
+    assert pyroscope_credentials.username == "profile-user"
+    assert pyroscope_credentials.password == "profile-token"
+
+
+def test_requirer_falls_back_to_shared_credentials(mycharm_context):
+    harness = Harness(
+        MyCharm,
+        meta="""
+name: my-charm
+requires:
+  grafana-cloud-config:
+    interface: grafana_cloud_config
+""",
+    )
+    harness.begin()
+    relation_id = harness.add_relation("grafana-cloud-config", "grafana-cloud-integrator")
+    harness.add_relation_unit(relation_id, "grafana-cloud-integrator/0")
+    harness.update_relation_data(
+        relation_id,
+        "grafana-cloud-integrator",
+        {
+            "prometheus_url": "https://prom.example/api/prom/push",
+            "loki_url": "https://logs.example/loki/api/v1/push",
+            "otlp_url": "https://otlp.example/otlp",
+            "pyroscope_url": "https://profiles.example",
+            "username": "shared-user",
+            "password": "shared-pass",
+        },
+    )
+
+    cloud = harness.charm.cloud
+    prometheus_credentials = cloud.prometheus_credentials
+    assert prometheus_credentials is not None
+    assert prometheus_credentials.username == "shared-user"
+    assert prometheus_credentials.password == "shared-pass"
+    loki_credentials = cloud.loki_credentials
+    assert loki_credentials is not None
+    assert loki_credentials.username == "shared-user"
+    assert loki_credentials.password == "shared-pass"
+    otlp_credentials = cloud.otlp_credentials
+    assert otlp_credentials is not None
+    assert otlp_credentials.username == "shared-user"
+    assert otlp_credentials.password == "shared-pass"
+    pyroscope_credentials = cloud.pyroscope_credentials
+    assert pyroscope_credentials is not None
+    assert pyroscope_credentials.username == "shared-user"
+    assert pyroscope_credentials.password == "shared-pass"

--- a/tests/unit/test_grafana_cloud_integrator_lib.py
+++ b/tests/unit/test_grafana_cloud_integrator_lib.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from charms.grafana_cloud_integrator.v0.cloud_config_requirer import (
     CloudConfigAvailableEvent,
@@ -168,3 +170,31 @@ requires:
     assert pyroscope_credentials is not None
     assert pyroscope_credentials.username == "shared-user"
     assert pyroscope_credentials.password == "shared-pass"
+
+
+def test_requirer_does_not_log_relation_databag_contents():
+    harness = Harness(
+        MyCharm,
+        meta="""
+name: my-charm
+requires:
+  grafana-cloud-config:
+    interface: grafana_cloud_config
+""",
+    )
+    harness.begin()
+    relation_id = harness.add_relation("grafana-cloud-config", "grafana-cloud-integrator")
+    harness.add_relation_unit(relation_id, "grafana-cloud-integrator/0")
+    harness.update_relation_data(
+        relation_id,
+        "grafana-cloud-integrator",
+        {
+            "username": "sensitive-user",
+            "password": "sensitive-pass",
+        },
+    )
+
+    with patch("charms.grafana_cloud_integrator.v0.cloud_config_requirer.logger.info") as info_log:
+        assert harness.charm.cloud.credentials is not None
+
+    info_log.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8, <4"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -602,7 +602,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -638,6 +638,7 @@ version = "0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "ops" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -664,6 +665,7 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-operator", marker = "extra == 'dev'" },
+    { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Issue

https://github.com/canonical/grafana-cloud-integrator/issues/41


## Solution

It adds a new config variable **signal-credentials** which accepts a yaml on the format:

```yaml
prometheus:
  username: "1076854"
  password: "<api-token>"
loki:
  username: "639149"
  password: "glc_loki_token"
tempo:
  username: "123456"
  password: "glc_tempo_token"
otlp:
  instance-id: "1076854"
  password: "glc_otlp_token"
pyroscope:
  username: "424242"
  password: "glc_pyroscope_token"
```

This will then allow grafana cloud for a number of signals.

It requires changes to the library as well. Also included in this PR.


## Context

Unless this feature exists, it can't be used with grafana cloud properly withour alot of separate deployed integrator instances.


## Testing Instructions

### Complete Example

This example configures:

- Prometheus remote write to Grafana Cloud
- Loki push to Grafana Cloud
- Tempo write to Grafana Cloud
- OTLP ingest to Grafana Cloud
- Pyroscope profile write to Grafana Cloud
- Separate credentials per signal

Create a `signals.yaml` file:

```yaml
prometheus:
  username: "1076854"
  password: "<api-token>"
loki:
  username: "639149"
  password: "glc_loki_token"
tempo:
  username: "123456"
  password: "glc_tempo_token"
otlp:
  instance-id: "1076854"
  password: "glc_otlp_token"
pyroscope:
  username: "424242"
  password: "glc_pyroscope_token"
```

If you also need to provide a custom CA, create `grafana-cloud-ca.pem`:

```pem
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```

Then configure the charm:

```sh
juju deploy grafana-cloud-integrator

juju config grafana-cloud-integrator \
  prometheus-url="https://prometheus-prod-39-prod-eu-north-0.grafana.net/api/prom/push"

juju config grafana-cloud-integrator \
  loki-url="https://logs-prod-025.grafana.net/loki/api/v1/push"

juju config grafana-cloud-integrator \
  tempo-url="https://tempo-prod-10-prod-eu-north-0.grafana.net/otlp"

juju config grafana-cloud-integrator \
  otlp-url="https://otlp-gateway-prod-eu-north-0.grafana.net/otlp"

juju config grafana-cloud-integrator \
  pyroscope-url="https://profiles-prod-010.grafana.net"

juju config grafana-cloud-integrator \
  signal-credentials="$(cat signals.yaml)"

juju config grafana-cloud-integrator \
  tls-ca="$(cat grafana-cloud-ca.pem)"
```

Relate a consumer charm that supports the `grafana-cloud-config` interface:

```sh
juju relate alloy-sub grafana-cloud-integrator
```

Or:

```sh
juju relate alloy-vm grafana-cloud-integrator
```

Check status:

```sh
juju status grafana-cloud-integrator
juju status alloy-sub
```

### Copy-Paste Ready Example

This example creates the credentials file and configures the integrator in one
go.

```sh
cat > signals.yaml <<'EOF'
prometheus:
  username: "1076854"
  password: "glc_prometheus_token"
loki:
  username: "639149"
  password: "glc_loki_token"
tempo:
  username: "123456"
  password: "glc_tempo_token"
otlp:
  instance-id: "1076854"
  password: "glc_otlp_token"
pyroscope:
  username: "424242"
  password: "glc_pyroscope_token"
EOF

juju deploy grafana-cloud-integrator --channel=stable

juju config grafana-cloud-integrator \
  prometheus-url="https://prometheus-prod-39-prod-eu-north-0.grafana.net/api/prom/push" \
  loki-url="https://logs-prod-025.grafana.net/loki/api/v1/push" \
  tempo-url="https://tempo-prod-10-prod-eu-north-0.grafana.net/otlp" \
  otlp-url="https://otlp-gateway-prod-eu-north-0.grafana.net/otlp" \
  pyroscope-url="https://profiles-prod-010.grafana.net" \
  signal-credentials="$(cat signals.yaml)"

juju relate alloy-sub grafana-cloud-integrator
